### PR TITLE
Improve type definitions to ensure ConnectionInfo is valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ see also [Releases](https://github.com/Dynatrace/OneAgent-SDK-for-NodeJs/release
 
 |Version|Description                                 |
 |:------|:-------------------------------------------|
+|1.2.1  |improve type definitions                    |
 |1.2.0  |add support for custom request attributes   |
 |1.1.0  |add setResultData() for SQL Database tracer |
 |1.0.3  |early access to beta                        |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace/oneagent-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Node.js SDK for Dynatrace OneAgent",
   "engines": {
     "node": ">= 4.0.0"
@@ -22,10 +22,7 @@
   "bugs": {
     "url": "https://github.com/Dynatrace/OneAgent-SDK-for-NodeJs/issues/"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Dynatrace/OneAgent-SDK-for-NodeJs.git"
-  },
+  "repository": "Dynatrace/OneAgent-SDK-for-NodeJs",
   "homepage": "https://www.dynatrace.com/technologies/nodejs-monitoring/",
   "keywords": [
     "dynatrace",
@@ -38,15 +35,15 @@
     "adk"
   ],
   "devDependencies": {
-    "@types/mocha": "5.2.2",
-    "@types/node": "10.3.3",
-    "@types/sinon": "5.0.1",
+    "@types/mocha": "5.2.5",
+    "@types/node": "10.12.12",
+    "@types/sinon": "5.0.7",
     "mocha": "5.2.0",
     "rimraf": "2.6.2",
-    "sinon": "6.0.0",
-    "source-map-support": "0.5.6",
-    "tslint": "5.10.0",
-    "typescript": "2.9.2"
+    "sinon": "7.1.1",
+    "source-map-support": "0.5.9",
+    "tslint": "5.11.0",
+    "typescript": "3.2.1"
   },
   "author": "Dynatrace",
   "license": "Apache-2.0"

--- a/samples/package.json
+++ b/samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdksamples",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Samples showing API for OneAgent SDK",
   "engines": {
     "node": ">= 8.0.0"
@@ -11,7 +11,7 @@
     "customrequestattribute": "node CustomRequestAttributes/CustomRequestAttributesSample.js"
   },
   "dependencies": {
-    "@dynatrace/oneagent-sdk": "1.2.0"
+    "@dynatrace/oneagent-sdk": "1.2.1"
   },
   "repository": {
     "type": "git",

--- a/src/Sdk.ts
+++ b/src/Sdk.ts
@@ -79,17 +79,14 @@ export const enum ChannelType {
 export interface ConnectionInfo {
 	/// The hostname/IP of the server-side in case a TCP/IP connection is used
 	host?: string;
-	// The port in case a TCP/IP connection is used
+	/// The port in case a TCP/IP connection is used
 	port?: number;
-
 
 	/// The path of the UNIX domain socket file
 	socketPath?: string;
 
-
 	/// The name of the pipe
 	pipeName?: string;
-
 
 	/// Set this field if no other field can be set
 	channelType?: ChannelType;
@@ -261,13 +258,32 @@ export interface OutgoingTaggable {
 /**
  * Description of a database.
  */
-export interface DatabaseInfo extends ConnectionInfo {
+export interface DatabaseInfoCommon extends ConnectionInfo {
 	/// The name of the database
 	name: string;
 
 	/// The database vendor name (e.a. Oracle, MySQL, ...) can be an user defined name. If possible use a constant defined in DatabaseVendor.
 	vendor: string;
 }
+
+export interface DatabaseInfoTcp extends DatabaseInfoCommon {
+	host: string;
+	port?: number;
+}
+
+export interface DatabaseInfoDomainSocket extends DatabaseInfoCommon {
+	socketPath: string;
+}
+
+export interface DatabaseInfoPipe extends DatabaseInfoCommon {
+	pipeName: string;
+}
+
+export interface DatabaseInfoChannelType extends DatabaseInfoCommon {
+	channelType: ChannelType;
+}
+
+export type DatabaseInfo = DatabaseInfoTcp | DatabaseInfoDomainSocket | DatabaseInfoPipe | DatabaseInfoChannelType;
 
 /**
  *  Specifies the SQL DatabaseTracer start data
@@ -332,7 +348,7 @@ export interface IncomingRemoteCallTracer extends IncomingTracer {
 /**
  * Specifies the start data for an outgoing remote call.
  */
-export interface OutgoingRemoteCallStartData extends ConnectionInfo {
+export interface OutgoingRemoteCallStartDataCommon extends ConnectionInfo {
 	/// Name of the called remote method
 	serviceMethod: string;
 
@@ -349,6 +365,25 @@ export interface OutgoingRemoteCallStartData extends ConnectionInfo {
 	/// The name of the protocol, only for display purposes
 	protocolName?: string;
 }
+
+export interface OutgoingRemoteCallStartDataTcp extends OutgoingRemoteCallStartDataCommon {
+	host: string;
+	port?: number;
+}
+
+export interface OutgoingRemoteCallStartDataDomainSocket extends OutgoingRemoteCallStartDataCommon {
+	socketPath: string;
+}
+
+export interface OutgoingRemoteCallStartDataPipe extends OutgoingRemoteCallStartDataCommon {
+	pipeName: string;
+}
+
+export interface OutgoingRemoteCallStartDataChannelType extends OutgoingRemoteCallStartDataCommon {
+	channelType: ChannelType;
+}
+
+export type OutgoingRemoteCallStartData = OutgoingRemoteCallStartDataTcp | OutgoingRemoteCallStartDataDomainSocket | OutgoingRemoteCallStartDataPipe | OutgoingRemoteCallStartDataChannelType;
 
 /**
  * Tracer for an outgoing remote call.

--- a/src/Stub.ts
+++ b/src/Stub.ts
@@ -18,6 +18,12 @@ import * as Sdk from "./Sdk";
 
 // ============================================================================
 
+const useNewBufferApi =  typeof(Buffer.alloc) === "function";
+
+function BufferFrom(str: string, encoding?: string): Buffer {
+	// tslint:disable-next-line:deprecation
+	return useNewBufferApi ? Buffer.from(str, encoding) : new Buffer(str, encoding);
+}
 
 class DummyTracer implements Sdk.Tracer {
 	public start<R>(handler: (...args: any[]) => R, ...args: any[]): R {
@@ -57,7 +63,7 @@ class DummyOutgoingTaggableTracer extends DummyOutgoingTracer implements Sdk.Tra
 		return "";
 	}
 	public getDynatraceByteTag(): Buffer {
-		return new Buffer("");
+		return BufferFrom("");
 	}
 }
 

--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,7 @@
 			"statements"
 		],
 		"comment-format": false,
+		"deprecation": true,
 		"no-empty-interface": false,
 		"indent": [
 			true,
@@ -24,21 +25,36 @@
 			true,
 			{
 				"order": [
-					"public-constructor",
-					"public-static-method",
-					"public-static-field",
-					"public-instance-method",
-					"public-instance-field",
-					"protected-constructor",
-					"protected-static-method",
-					"protected-static-field",
-					"protected-instance-method",
-					"protected-instance-field",
-					"private-constructor",
-					"private-static-method",
-					"private-static-field",
-					"private-instance-method",
-					"private-instance-field"
+					{
+						"name": "public",
+						"kinds": [
+							"public-static-field",
+							"public-static-method",
+							"public-instance-field",
+							"public-constructor",
+							"public-instance-method"
+						]
+					},
+					{
+						"name": "protected",
+						"kinds": [
+							"protected-static-field",
+							"protected-static-method",
+							"protected-instance-field",
+							"protected-constructor",
+							"protected-instance-method"
+						]
+					},
+					{
+						"name": "private",
+						"kinds": [
+							"private-static-field",
+							"private-static-method",
+							"private-instance-field",
+							"private-constructor",
+							"private-instance-method"
+						]
+					}
 				]
 			}
 		],
@@ -46,6 +62,8 @@
 			true,
 			5
 		],
+		"no-unnecessary-type-assertion": true,
+		"no-unused-expression": [true, "allow-new"],
 		"object-literal-shorthand": false,
 		"object-literal-sort-keys": false,
 		"ordered-imports": false,
@@ -58,9 +76,17 @@
 		]
 	},
 	"jsRules": {
+		"indent": [
+			true,
+			"tabs"
+		],
 		"max-line-length": [
 			true,
 			200
+		],
+		"no-consecutive-blank-lines": [
+			true,
+			5
 		],
 		"object-literal-sort-keys": false,
 		"trailing-comma": [


### PR DESCRIPTION
One field of ConnectionInfo needs to be set otherwise SDK will reject to create a tracer.

Fixes: https://github.com/Dynatrace/OneAgent-SDK-for-NodeJs/issues/1